### PR TITLE
fix(ci): reduce Claude workflow permissions for comment-triggered runs

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -19,9 +19,9 @@ jobs:
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
     runs-on: ubuntu-latest
     permissions:
-      contents: write
-      pull-requests: write
-      issues: write
+      contents: read
+      pull-requests: read
+      issues: read
       id-token: write
       actions: read
     steps:


### PR DESCRIPTION
### Motivation
- The `claude` job was triggerable by untrusted comment/issue events containing `@claude` while running with repository `write` permissions, which permitted privilege escalation by malicious commenters.

### Description
- In `.github/workflows/claude.yml` changed `contents`, `pull-requests`, and `issues` permissions from `write` to `read` while leaving `id-token: write` and `actions: read` unchanged to remove unnecessary repository write capability for comment-triggered runs.

### Testing
- Ran `npm run build` successfully; ran `cd src-tauri && cargo check` which failed in this environment due to missing system `glib/gio/gobject` pkg-config libraries and not because of the workflow YAML change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69ada1620aec8322963f669770550a77)